### PR TITLE
Changed "fork me" link target.

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
     </nav>
 
     <!-- Fork me on github -->
-    <a href="https://github.com/black-perl"><img style="z-index:5000;position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
+    <a href="https://github.com/black-perl/ptop"><img style="z-index:5000;position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
 
     <!-- Page Content -->
     <div class="container">
@@ -108,10 +108,10 @@
 
         <div class="row">
             <div class="col-md-6">
-                <img src="https://raw.githubusercontent.com/black-perl/ptop/master/docs/ptop1.png" alt="ptop -1"> 
+                <img src="https://raw.githubusercontent.com/black-perl/ptop/master/docs/ptop1.png" alt="ptop -1">
             </div>
             <div class="col-md-6">
-                <img src="https://raw.githubusercontent.com/black-perl/ptop/master/docs/ptop2.png" alt="ptop -2"> 
+                <img src="https://raw.githubusercontent.com/black-perl/ptop/master/docs/ptop2.png" alt="ptop -2">
             </div>
         </div>
         <br/>
@@ -119,11 +119,11 @@
         <div class="row">
             <div class="col-lg-2"></div>
             <div class="col-lg-8">
-                <img src="https://raw.githubusercontent.com/black-perl/ptop/master/docs/ptop.png" alt="ptop-3"> 
+                <img src="https://raw.githubusercontent.com/black-perl/ptop/master/docs/ptop.png" alt="ptop-3">
             </div>
             <div class="col-lg-2"></div>
         </div>
-        
+
         <br/>
         <br/>
     </div>
@@ -144,12 +144,12 @@
           js.id = id;
           js.src = "https://platform.twitter.com/widgets.js";
           fjs.parentNode.insertBefore(js, fjs);
-         
+
           t._e = [];
           t.ready = function(f) {
             t._e.push(f);
           };
-         
+
           return t;
         }(document, "script", "twitter-wjs"));
     </script>

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
     </nav>
 
     <!-- Fork me on github -->
-    <a href="https://github.com/black-perl/ptop"><img style="z-index:5000;position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
+    <a href="https://github.com/black-perl/ptop#fork-destination-box"><img style="z-index:5000;position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
 
     <!-- Page Content -->
     <div class="container">


### PR DESCRIPTION
This might have been intended, but the link on the fork-me banner was pointing to your personal github account, not the repository.

I changed it, it's pointing to the repo now.

The rest is automatic whitespace removal by the editor. I was too lazy to uncommit it :D