### PR TITLE
update : fix process uptime and memory alignments

### DIFF
--- a/ptop/interfaces/GUI.py
+++ b/ptop/interfaces/GUI.py
@@ -211,7 +211,7 @@ class PtopGUI(npyscreen.NPSApp):
             if MEMORY_SORT:
                 sorted_table = sorted(processes_table,key=lambda k:k['memory'],reverse=True)
             elif TIME_SORT:
-                sorted_table = sorted(processes_table,key=lambda k:k['time'],reverse=True)
+                sorted_table = sorted(processes_table,key=lambda k:k['rawtime'],reverse=True)
             else:
                 sorted_table = processes_table
 
@@ -219,7 +219,7 @@ class PtopGUI(npyscreen.NPSApp):
             temp_list = []
             for proc in sorted_table:
                 if proc['user'] == system_info['user']:
-                    temp_list.append("{0: <30} {1: >5}{5}{2: <10}{5}{3: <8}{5}{4: <4} % \
+                    temp_list.append("{0: <30} {1: >5}{5}{2: <10}{5}{3}{5}{4: >6.2f} % \
                     ".format( (proc['name'][:25] + '...') if len(proc['name']) > 25 else proc['name'],
                                proc['id'],
                                proc['user'],

--- a/ptop/plugins/process_sensor.py
+++ b/ptop/plugins/process_sensor.py
@@ -16,6 +16,14 @@ class ProcessSensor(Plugin):
         # nested structure is used for keeping the info of processes
         self.currentValue['table'] = []
 
+    def format_time(self, d):
+        ret = '{0} day{1} '.format(d.days, ' s'[d.days > 1]) if d.days else ''
+        h = d.seconds // 3600
+        s = d.seconds - 3600 * h
+        m = s // 60
+        s -= m * 60
+        return ret + '{0:2d}:{1:02d}:{2:02d}'.format(h, m, s)
+
     # overriding the upate method
     def update(self):
         # flood the data
@@ -31,7 +39,8 @@ class ProcessSensor(Plugin):
             p = psutil.Process(proc.pid)
             proc_info['user'] = p.username()
             delta = datetime.timedelta(seconds=(time.time() - p.create_time()))
-            proc_info['time'] =  str(delta).split('.')[0]
+            proc_info['rawtime'] = delta
+            proc_info['time'] =  self.format_time(delta)
             proc_info['cpu'] = p.cpu_percent()
             proc_info['memory'] = round(p.memory_percent(),2)
             proc_info['command'] = ' '.join(p.cmdline())
@@ -40,6 +49,11 @@ class ProcessSensor(Plugin):
             proc_count += 1
             # recording the info
             proc_info_list.append(proc_info)
+
+        # padding time
+        time_len = max((len(proc['time']) for proc in proc_info_list))
+        for proc in proc_info_list:
+            proc['time'] = '{0: >{1}}'.format(proc['time'], time_len)
 
         self.currentValue['table'] = []
         self.currentValue['table'].extend(proc_info_list)


### PR DESCRIPTION
In processes list, the uptime is reversely sorted by string sort, which may be incorrectly sorted, for example

```
9:01:23
3 day 1:12:23
21:02:45
```

Which is correct if by string sort, but not what we want. This patch adds a format function to pad the strings, so it can be sorted correct by string sort. However, a proc_info['rawtime'] is added for time delta as sorting key even it's not necessary with this new format function, it's safer to sort the raw data than its representation. The drawback is the uptime is fixed in English.

The alignment for memory usage percentage is also fixed with proper padding and float type.