### PR TITLE
Show CPU usage, sorting and reverse sorting

### DIFF
--- a/ptop/interfaces/GUI.py
+++ b/ptop/interfaces/GUI.py
@@ -478,15 +478,15 @@ class PtopGUI(npyscreen.NPSApp):
             # to keep things pre computed
             curtailed_processes_data = []
             for proc in sorted_processes_data:
-                curtailed_processes_data.append("{0: <30} {1: >5}{6}{2: <10}{6}{3}{6}{4: >6.2f} % {6}{5}\
-                ".format( (proc['name'][:25] + '...') if len(proc['name']) > 25 else proc['name'],
-                           proc['id'],
-                           proc['user'],
-                           proc['time'],
-                           proc['memory'],
-                           proc['local_ports'],
-                           " "*int(5*self.X_SCALING_FACTOR))
-                )
+                curtailed_processes_data.append("{0: <30}{1: >7}{7}{2: <10}{7}{3}{7}{4}{7}{5}{7}{6}\
+                ".format((proc['name'][:25] + '...') if len(proc['name']) > 25 else proc['name'],
+                          proc['id'],
+                          proc['user'],
+                          proc['time'],
+                          self.format_percentage(proc['cpu']),
+                          self.format_percentage(proc['memory']),
+                          proc['local_ports'],
+                          " " * int(5 * self.X_SCALING_FACTOR)))
             if not self.processes_table.entry_widget.is_filtering_on():
                 self.processes_table.entry_widget.values =  curtailed_processes_data
             # Set the processes data dictionary to uncurtailed processes data
@@ -502,6 +502,10 @@ class PtopGUI(npyscreen.NPSApp):
         # cumbersome point of reading the stats data structures
         except KeyError:
             self._logger.info("Some of the stats reading failed",exc_info=True)
+
+    @staticmethod
+    def format_percentage(float_value):
+        return f'{float_value: >6.2f}'.rjust(2, ' ') + ' %'
 
     def draw(self):
         # Setting the main window form
@@ -610,7 +614,7 @@ class PtopGUI(npyscreen.NPSApp):
                                                                                                 PROCESSES_INFO_WIDGET_REL_Y+PROCESSES_INFO_WIDGET_HEIGHT)
                                                                                                 )
         self.processes_table = self.window.add(MultiLineActionWidget,
-                                               name="Processes ( name - PID - user - age - memory - system_ports )",
+                                               name="Processes ( name - PID - user - age - cpu - memory - system_ports )",
                                                relx=PROCESSES_INFO_WIDGET_REL_X,
                                                rely=PROCESSES_INFO_WIDGET_REL_Y,
                                                max_height=PROCESSES_INFO_WIDGET_HEIGHT,

--- a/ptop/plugins/process_sensor.py
+++ b/ptop/plugins/process_sensor.py
@@ -22,6 +22,8 @@ class ProcessSensor(Plugin):
         self.currentValue['table'] = []
         self._currentSystemUser = getpass.getuser()
         self._logger = logging.getLogger(__name__)
+        # processes once retrieved from psutil are stored in a list to make cpu percentage measurement possible
+        self._process_list = []
 
     def format_time(self, d):
         ret = '{0} day{1} '.format(d.days, ' s'[d.days > 1]) if d.days else ''
@@ -31,7 +33,7 @@ class ProcessSensor(Plugin):
         s -= m * 60
         return ret + '{0:2d}:{1:02d}:{2:02d}'.format(h, m, s)
 
-    # overriding the upate method
+    # overriding the update method
     def update(self):
         # flood the data
         thread_count = 0 #keep track number of threads
@@ -50,7 +52,7 @@ class ProcessSensor(Plugin):
              because getting further process info for root processes as a normal 
              user will give Permission Denied #10
             '''
-            p = psutil.Process(proc.pid)
+            p = self.retrieve_process_by_pid(proc.pid)
             proc_info['user'] = p.username()
             try:
                 if ((proc_info['user'] == self._currentSystemUser) or (self._currentSystemUser in PRIVELAGED_USERS)) \
@@ -75,16 +77,12 @@ class ProcessSensor(Plugin):
                         SYSTEM_USERS.append(proc_info['user'])
             except:
                 '''
-                    In case ptop does not have privelages to access info for some of the processes
+                    In case ptop does not have privileges to access info for some of the processes
                     just log them and don't show them in the processes table
                 '''
-                self._logger.info('''Not able to get info for process {0} with status {1} invoked by user {2}, ptop
-                                   is invoked by the user {3}'''.format(str(p.pid),
-                                                                        p.status(),
-                                                                        p.username(),
-                                                                        self._currentSystemUser
-                                                                        ),
-                                                                        exc_info=True)
+                self._logger.info(f"""Not able to get info for process {p.pid} with status {p.status()} invoked by user {p.username()}, ptop
+                                   is invoked by the user {self._currentSystemUser}""",
+                                  exc_info=True)
 
         # padding time
         time_len = max((len(proc['time']) for proc in proc_info_list))
@@ -95,6 +93,14 @@ class ProcessSensor(Plugin):
         self.currentValue['table'].extend(proc_info_list)
         self.currentValue['text']['running_processes'] = str(proc_count)
         self.currentValue['text']['running_threads'] = str(thread_count)
+
+    def retrieve_process_by_pid(self, pid):
+        found_processes = [x for x in self._process_list if x.pid == pid]
+        process = found_processes[0] if len(found_processes) > 0 else psutil.Process(pid)
+        if not found_processes and process:
+            self._process_list.append(process)
+        return process
+
 
 # make the process sensor less frequent as it takes more time to fetch info
 process_sensor = ProcessSensor(name='Process',sensorType='table',interval=1)


### PR DESCRIPTION
I really like ptop but it lacks showing CPU usage (well, lacked...)
Now ptop is able to show processes' CPU usage and sort the list with `ctrl + U` shortcut where `U` stands for `Usage`, as `C` for `CPU` was taken 🙃.
Also, now it's possible to reverse-sort the list.
![image](https://user-images.githubusercontent.com/1781044/92186503-4545f700-ee57-11ea-8f43-3ef77f8d28f1.png)
 